### PR TITLE
Fix for status change handling and other minor changes

### DIFF
--- a/overrides.pas
+++ b/overrides.pas
@@ -14,7 +14,7 @@ implementation
 procedure myloggingoutputhandler(AFacility,ASeverity:LongWord;const ATag,AContent:String);
 begin
 //  if (atag <> 'USB') and (atag <> 'Device') then
-    if (atag = 'WIFIdevice') or (atag = 'MMC') then
+    if (atag = 'WIFIdevice') or (atag = 'MMC') or (atag = 'Network') then
       log('('+atag+')' + ' ' + acontent);
 end;
 

--- a/wifi.lpr
+++ b/wifi.lpr
@@ -369,7 +369,9 @@ begin
   LoggingConsoleDeviceAdd(ConsoleDeviceGetDefault);
   LoggingDeviceSetDefault(LoggingDeviceFindByType(LOGGING_TYPE_CONSOLE));
 
-  LoggingOutputExHandler:= @myloggingoutputhandler;
+  // Filter the logs so we only see the WiFi and MMC device events
+  // (Primarily development use, otherwise you don't see network events etc)
+  //LoggingOutputExHandler:= @myloggingoutputhandler; 
 
   HTTPListener:=THTTPListener.Create;
   HTTPListener.Active:=True;
@@ -472,6 +474,16 @@ begin
       end;
     end;
 
+    // Setup a slow blink of the activity LED to give an indcation that the Pi is still alive
+    ActivityLEDEnable;
+    
+    while True do
+    begin
+      ActivityLEDOn;
+      Sleep(500);
+      ActivityLEDOff;
+      Sleep(500);
+    end;
   except
     on e : exception do
       ConsoleWindowWriteln(topwindow, 'Exception: ' + e.message + ' at ' + inttohex(longword(exceptaddr), 8));


### PR DESCRIPTION
Modify Up / Down status handling to correctly notify network stack on change of status
Add LED blink in main thread to provide device alive indication
Allow Network events to be displayed by the log filtering
Move setup of GPIO pins to later in initialization to handle changes in next Ultibo release