### PR TITLE
Fix for Pi Zero W failures

### DIFF
--- a/wifidevice.pas
+++ b/wifidevice.pas
@@ -5338,6 +5338,13 @@ begin
   begin
     if (firmware[i].chipid = WIFI^.chipid) and (firmware[i].chipidrev = WIFI^.chipidrev) then
     begin
+      // If no regulatory file just succeed
+      if Length(firmware[i].regufilename) = 0 then
+      begin
+        Result := WIFI_STATUS_SUCCESS;
+        Exit;
+      end;  
+
       RegulatoryFilename := FIRMWARE_FILENAME_ROOT + firmware[i].regufilename;
       Found := true;
       break;
@@ -5873,6 +5880,11 @@ begin
  Result := WirelessSetInt(WIFI, 'bus:txglom', 0);
  if Result <> WIFI_STATUS_SUCCESS then
   exit;
+
+ Result := WirelessSetInt(WIFI, 'bus:rxglom', 0);
+ // Linux driver says this is allowed to fail
+ //if Result <> WIFI_STATUS_SUCCESS then
+ // exit;
 
  Result := WirelessSetInt(WIFI, 'bcn_timeout', 10);
  if Result <> WIFI_STATUS_SUCCESS then


### PR DESCRIPTION
This is a fix for the channel type 3 packet failures on Pi Zero W, the upload of the regulatory file was failing (as there isn't one for the Zero) and the rest of the init process was not occurring. 

For good measure this also adds the option to disable rxglom which is what channel 3 packets are.

Note: Only tested on Pi Zero, please retest against other models to confirm no other impacts.